### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -4,10 +4,10 @@
 # Class
 ###################################################################
 
-Paint KEYWORD1
+Paint	KEYWORD1
 Epd	KEYWORD1
-epd1in54 KEYWORD1
-epdpaint KEYWORD1
+epd1in54	KEYWORD1
+epdpaint	KEYWORD1
 
 ###################################################################
 # Methods and Functions
@@ -25,7 +25,7 @@ DrawRectangle	KEYWORD2
 DrawLine	KEYWORD2
 DrawCircle	KEYWORD2
 DrawFilledRectangle	KEYWORD2
-Init KEYWORD2
+Init	KEYWORD2
 
 
 ###################################################################


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords